### PR TITLE
Fix combining service stats by using max()

### DIFF
--- a/pkg/traceql/combine.go
+++ b/pkg/traceql/combine.go
@@ -70,7 +70,7 @@ func combineSearchResults(existing *tempopb.TraceSearchMetadata, incoming *tempo
 		existing.DurationMs = incoming.DurationMs
 	}
 
-	// Merge service stats
+	// Combine service stats
 	// It's possible to find multiple trace fragments that satisfy a TraceQL result,
 	// therefore we use max() to merge the ServiceStats.
 	for service, incomingStats := range incoming.ServiceStats {

--- a/pkg/traceql/combine.go
+++ b/pkg/traceql/combine.go
@@ -71,14 +71,16 @@ func combineSearchResults(existing *tempopb.TraceSearchMetadata, incoming *tempo
 	}
 
 	// Merge service stats
+	// It's possible to find multiple trace fragments that satisfy a TraceQL result,
+	// therefore we use max() to merge the ServiceStats.
 	for service, incomingStats := range incoming.ServiceStats {
 		existingStats, ok := existing.ServiceStats[service]
 		if !ok {
 			existingStats = &tempopb.ServiceStats{}
 			existing.ServiceStats[service] = existingStats
 		}
-		existingStats.SpanCount += incomingStats.SpanCount
-		existingStats.ErrorCount += incomingStats.ErrorCount
+		existingStats.SpanCount = max(existingStats.SpanCount, incomingStats.SpanCount)
+		existingStats.ErrorCount = max(existingStats.ErrorCount, incomingStats.ErrorCount)
 	}
 
 	// make a map of existing Spansets

--- a/pkg/traceql/combine_test.go
+++ b/pkg/traceql/combine_test.go
@@ -193,6 +193,33 @@ func TestCombineResults(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "merge ServiceStats",
+			existing: &tempopb.TraceSearchMetadata{
+				ServiceStats: map[string]*tempopb.ServiceStats{
+					"service1": {
+						SpanCount:  5,
+						ErrorCount: 1,
+					},
+				},
+			},
+			new: &tempopb.TraceSearchMetadata{
+				ServiceStats: map[string]*tempopb.ServiceStats{
+					"service1": {
+						SpanCount:  3,
+						ErrorCount: 2,
+					},
+				},
+			},
+			expected: &tempopb.TraceSearchMetadata{
+				ServiceStats: map[string]*tempopb.ServiceStats{
+					"service1": {
+						SpanCount:  5,
+						ErrorCount: 2,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
Fix combining service stats by using max()

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`