### PR TITLE
Add ServiceStats data to existing TraceQL engine tests

### DIFF
--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -35,6 +35,12 @@ func TestEngine_Execute(t *testing.T) {
 					TraceID:         []byte{1},
 					RootSpanName:    "HTTP GET",
 					RootServiceName: "my-service",
+					ServiceStats: map[string]ServiceStats{
+						"my-service": {
+							SpanCount:  6,
+							ErrorCount: 0,
+						},
+					},
 					Spans: []Span{
 						&mockSpan{
 							id: []byte{1},
@@ -167,9 +173,14 @@ func TestEngine_Execute(t *testing.T) {
 			TraceID:         "1",
 			RootServiceName: "my-service",
 			RootTraceName:   "HTTP GET",
-			ServiceStats:    map[string]*tempopb.ServiceStats{},
-			SpanSet:         expectedSpanset,
-			SpanSets:        []*tempopb.SpanSet{expectedSpanset},
+			ServiceStats: map[string]*tempopb.ServiceStats{
+				"my-service": {
+					SpanCount:  6,
+					ErrorCount: 0,
+				},
+			},
+			SpanSet:  expectedSpanset,
+			SpanSets: []*tempopb.SpanSet{expectedSpanset},
 		},
 	}
 
@@ -206,6 +217,12 @@ func TestEngine_asTraceSearchMetadata(t *testing.T) {
 		RootSpanName:       "HTTP GET",
 		StartTimeUnixNanos: 1000,
 		DurationNanos:      uint64(time.Second.Nanoseconds()),
+		ServiceStats: map[string]ServiceStats{
+			"service1": {
+				SpanCount:  2,
+				ErrorCount: 1,
+			},
+		},
 		Spans: []Span{
 			&mockSpan{
 				id:                 spanID1,
@@ -322,9 +339,14 @@ func TestEngine_asTraceSearchMetadata(t *testing.T) {
 		RootTraceName:     "HTTP GET",
 		StartTimeUnixNano: 1000,
 		DurationMs:        uint32(time.Second.Milliseconds()),
-		ServiceStats:      map[string]*tempopb.ServiceStats{},
-		SpanSet:           expectedSpanset,
-		SpanSets:          []*tempopb.SpanSet{expectedSpanset},
+		ServiceStats: map[string]*tempopb.ServiceStats{
+			"service1": {
+				SpanCount:  2,
+				ErrorCount: 1,
+			},
+		},
+		SpanSet:  expectedSpanset,
+		SpanSets: []*tempopb.SpanSet{expectedSpanset},
 	}
 
 	// Ensure attributes are sorted to avoid a flaky test


### PR DESCRIPTION
Add ServiceStats data to existing TraceQL engine tests

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`