### PR TITLE
Recalculate ServiceStats in combiner by moving it to assignNestedSetModelBounds()

### DIFF
--- a/tempodb/encoding/vparquet4/combiner.go
+++ b/tempodb/encoding/vparquet4/combiner.go
@@ -87,14 +87,6 @@ func (c *Combiner) ConsumeWithFinal(tr *Trace, final bool) (spanCount int) {
 	}
 	c.result.DurationNano = c.result.EndTimeUnixNano - c.result.StartTimeUnixNano
 
-	// Merge service stats
-	for service, incomingStats := range tr.ServiceStats {
-		combinedStats := c.result.ServiceStats[service]
-		combinedStats.SpanCount += incomingStats.SpanCount
-		combinedStats.ErrorCount += incomingStats.ErrorCount
-		c.result.ServiceStats[service] = combinedStats
-	}
-
 	// loop through every span and copy spans in B that don't exist to A
 	for _, b := range tr.ResourceSpans {
 		notFoundILS := b.ScopeSpans[:0]
@@ -142,7 +134,7 @@ func (c *Combiner) Result() (*Trace, int, bool) {
 	if c.result != nil && c.combined {
 		// Only if anything combined
 		SortTrace(c.result)
-		connected = assignNestedSetModelBounds(c.result)
+		connected = assignNestedSetModelBoundsAndServiceStats(c.result)
 		spanCount = len(c.spans)
 	}
 

--- a/tempodb/encoding/vparquet4/nested_set_model_test.go
+++ b/tempodb/encoding/vparquet4/nested_set_model_test.go
@@ -308,3 +308,82 @@ func assertEqualNestedSetModelBounds(t testing.TB, actual, expected *Trace) {
 
 	assert.Equalf(t, expectedCount, actualCount, "expected %d spans but found %d instead", expectedCount, actualCount)
 }
+
+func TestAssignServiceStats(t *testing.T) {
+	tests := []struct {
+		name     string
+		trace    []ResourceSpans
+		expected map[string]ServiceStats
+	}{
+		{
+			name: "single span",
+			trace: []ResourceSpans{
+				{
+					Resource: Resource{ServiceName: "serviceA"},
+					ScopeSpans: []ScopeSpans{{
+						Spans: []Span{
+							{SpanID: []byte("aaaaaaaa")},
+						},
+					}},
+				},
+			},
+			expected: map[string]ServiceStats{"serviceA": {SpanCount: 1}},
+		},
+		{
+			name: "multiple services",
+			trace: []ResourceSpans{
+				{
+					Resource: Resource{ServiceName: "serviceA"},
+					ScopeSpans: []ScopeSpans{{
+						Spans: []Span{
+							{SpanID: []byte("aaaaaaaa")},
+							{SpanID: []byte("aaaaaaab")},
+						},
+					}},
+				},
+				{
+					Resource: Resource{ServiceName: "serviceB"},
+					ScopeSpans: []ScopeSpans{{
+						Spans: []Span{
+							{SpanID: []byte("aaaaaaac")},
+						},
+					}},
+				},
+			},
+			expected: map[string]ServiceStats{"serviceA": {SpanCount: 2}, "serviceB": {SpanCount: 1}},
+		},
+		{
+			name: "multiple services with errors",
+			trace: []ResourceSpans{
+				{
+					Resource: Resource{ServiceName: "serviceA"},
+					ScopeSpans: []ScopeSpans{{
+						Spans: []Span{
+							{SpanID: []byte("aaaaaaaa"), StatusCode: 0},
+							{SpanID: []byte("aaaaaaab"), StatusCode: 2},
+						},
+					}},
+				},
+				{
+					Resource: Resource{ServiceName: "serviceB"},
+					ScopeSpans: []ScopeSpans{{
+						Spans: []Span{
+							{SpanID: []byte("aaaaaaac"), StatusCode: 1},
+							{SpanID: []byte("aaaaaaad"), StatusCode: 2},
+							{SpanID: []byte("aaaaaaae"), StatusCode: 2},
+						},
+					}},
+				},
+			},
+			expected: map[string]ServiceStats{"serviceA": {SpanCount: 2, ErrorCount: 1}, "serviceB": {SpanCount: 3, ErrorCount: 2}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trace := &Trace{ResourceSpans: tt.trace}
+			assignNestedSetModelBoundsAndServiceStats(trace)
+			assert.Equal(t, tt.expected, trace.ServiceStats)
+		})
+	}
+}

--- a/tempodb/encoding/vparquet4/nested_set_model_test.go
+++ b/tempodb/encoding/vparquet4/nested_set_model_test.go
@@ -269,7 +269,7 @@ func TestAssignNestedSetModelBounds(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			trace := makeTrace(tt.trace)
 			expected := makeTrace(tt.expected)
-			connected := assignNestedSetModelBounds(trace)
+			connected := assignNestedSetModelBoundsAndServiceStats(trace)
 			assertEqualNestedSetModelBounds(t, trace, expected)
 			assert.Equal(t, tt.expectedConnected, connected)
 		})

--- a/tempodb/encoding/vparquet4/schema.go
+++ b/tempodb/encoding/vparquet4/schema.go
@@ -557,24 +557,7 @@ func traceToParquet(meta *backend.BlockMeta, id common.ID, tr *tempopb.Trace, ot
 		}
 	}
 
-	// Calculate service meta information/statistics per trace
-	ot.ServiceStats = map[string]ServiceStats{}
-	for _, res := range ot.ResourceSpans {
-		stats := ot.ServiceStats[res.Resource.ServiceName]
-
-		for _, ss := range res.ScopeSpans {
-			stats.SpanCount += uint32(len(ss.Spans))
-			for _, s := range ss.Spans {
-				if s.StatusCode == int(v1_trace.Status_STATUS_CODE_ERROR) {
-					stats.ErrorCount++
-				}
-			}
-		}
-
-		ot.ServiceStats[res.Resource.ServiceName] = stats
-	}
-
-	return ot, assignNestedSetModelBounds(ot)
+	return ot, assignNestedSetModelBoundsAndServiceStats(ot)
 }
 
 func instrumentationScopeToParquet(s *v1.InstrumentationScope, ss *InstrumentationScope) {


### PR DESCRIPTION
Recalculate ServiceStats in combiner by moving it to assignNestedSetModelBounds()

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`