### PR TITLE
Move serviceStats iterator to second pass

### DIFF
--- a/pkg/traceql/enum_attributes.go
+++ b/pkg/traceql/enum_attributes.go
@@ -9,6 +9,7 @@ const (
 	AttributeScopeResource
 	AttributeScopeSpan
 	AttributeScopeUnknown
+	AttributeScopeTrace
 
 	none     = "none"
 	duration = "duration"

--- a/pkg/traceql/storage.go
+++ b/pkg/traceql/storage.go
@@ -12,6 +12,10 @@ type Condition struct {
 	Operands  Operands
 }
 
+const (
+	ServiceStatsAttributeName = "ServiceStats"
+)
+
 func SearchMetaConditions() []Condition {
 	return []Condition{
 		{NewIntrinsic(IntrinsicTraceRootService), OpNone, nil},
@@ -22,6 +26,7 @@ func SearchMetaConditions() []Condition {
 		{NewIntrinsic(IntrinsicSpanID), OpNone, nil},
 		{NewIntrinsic(IntrinsicSpanStartTime), OpNone, nil},
 		{NewIntrinsic(IntrinsicDuration), OpNone, nil},
+		{Attribute{Scope: AttributeScopeTrace, Name: ServiceStatsAttributeName}, OpNone, nil},
 	}
 }
 

--- a/pkg/traceql/storage_test.go
+++ b/pkg/traceql/storage_test.go
@@ -73,6 +73,7 @@ func TestMetaConditionsWithout(t *testing.T) {
 				{NewIntrinsic(IntrinsicTraceStartTime), OpNone, nil},
 				{NewIntrinsic(IntrinsicSpanID), OpNone, nil},
 				{NewIntrinsic(IntrinsicSpanStartTime), OpNone, nil},
+				{Attribute{Scope: AttributeScopeTrace, Name: ServiceStatsAttributeName}, OpNone, nil},
 			},
 		},
 		{
@@ -83,6 +84,7 @@ func TestMetaConditionsWithout(t *testing.T) {
 				{NewIntrinsic(IntrinsicTraceStartTime), OpNone, nil},
 				{NewIntrinsic(IntrinsicSpanID), OpNone, nil},
 				{NewIntrinsic(IntrinsicSpanStartTime), OpNone, nil},
+				{Attribute{Scope: AttributeScopeTrace, Name: ServiceStatsAttributeName}, OpNone, nil},
 			},
 		},
 	}

--- a/tempodb/encoding/vparquet/block_traceql.go
+++ b/tempodb/encoding/vparquet/block_traceql.go
@@ -740,7 +740,7 @@ func createAllIterator(ctx context.Context, primaryIter parquetquery.Iterator, c
 			resourceConditions = append(resourceConditions, cond)
 			continue
 
-		case intrinsicScopeTrace:
+		case traceql.AttributeScopeTrace, intrinsicScopeTrace:
 			traceConditions = append(traceConditions, cond)
 			continue
 

--- a/tempodb/encoding/vparquet2/block_traceql.go
+++ b/tempodb/encoding/vparquet2/block_traceql.go
@@ -924,7 +924,7 @@ func createAllIterator(ctx context.Context, primaryIter parquetquery.Iterator, c
 			resourceConditions = append(resourceConditions, cond)
 			continue
 
-		case intrinsicScopeTrace:
+		case traceql.AttributeScopeTrace, intrinsicScopeTrace:
 			traceConditions = append(traceConditions, cond)
 			continue
 

--- a/tempodb/encoding/vparquet3/block_traceql.go
+++ b/tempodb/encoding/vparquet3/block_traceql.go
@@ -1039,7 +1039,7 @@ func categorizeConditions(conditions []traceql.Condition) (mingled bool, spanCon
 			resourceConditions = append(resourceConditions, cond)
 			continue
 
-		case intrinsicScopeTrace:
+		case traceql.AttributeScopeTrace, intrinsicScopeTrace:
 			traceConditions = append(traceConditions, cond)
 			continue
 

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -818,6 +818,7 @@ func (i *rebatchIterator) Next() (*parquetquery.IteratorResult, error) {
 				sp.cbSpanset.StartTimeUnixNanos = ss.StartTimeUnixNanos
 			}
 			if len(sp.cbSpanset.ServiceStats) == 0 {
+				sp.cbSpanset.ServiceStats = map[string]traceql.ServiceStats{}
 				for service, stat := range ss.ServiceStats {
 					sp.cbSpanset.ServiceStats[service] = traceql.ServiceStats{
 						SpanCount:  stat.SpanCount,

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -818,7 +818,12 @@ func (i *rebatchIterator) Next() (*parquetquery.IteratorResult, error) {
 				sp.cbSpanset.StartTimeUnixNanos = ss.StartTimeUnixNanos
 			}
 			if len(sp.cbSpanset.ServiceStats) == 0 {
-				sp.cbSpanset.ServiceStats = ss.ServiceStats
+				for service, stat := range ss.ServiceStats {
+					sp.cbSpanset.ServiceStats[service] = traceql.ServiceStats{
+						SpanCount:  stat.SpanCount,
+						ErrorCount: stat.ErrorCount,
+					}
+				}
 			}
 
 			i.nextSpans = append(i.nextSpans, sp)
@@ -1046,7 +1051,7 @@ func categorizeConditions(conditions []traceql.Condition) (mingled bool, spanCon
 			resourceConditions = append(resourceConditions, cond)
 			continue
 
-		case intrinsicScopeTrace:
+		case traceql.AttributeScopeTrace, intrinsicScopeTrace:
 			traceConditions = append(traceConditions, cond)
 			continue
 
@@ -1495,14 +1500,16 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 			}
 			traceIters = append(traceIters, makeIter(columnPathRootServiceName, pred, columnPathRootServiceName))
 		}
+
+		switch cond.Attribute.Name {
+		case traceql.ServiceStatsAttributeName:
+			traceIters = append(traceIters, createServiceStatsIterator(makeIter))
+		}
 	}
 
 	// order is interesting here. would it be more efficient to grab the span/resource conditions first
 	// or the time range filtering first?
 	traceIters = append(traceIters, resourceIter)
-
-	// collect service stats of the trace
-	traceIters = append(traceIters, createServiceStatsIterator(makeIter))
 
 	// evaluate time range
 	// Time range filtering?
@@ -1520,7 +1527,7 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 
 	// Final trace iterator
 	// Join iterator means it requires matching resources to have been found
-	// TraceCollor adds trace-level data to the spansets
+	// TraceCollector adds trace-level data to the spansets
 	return parquetquery.NewJoinIterator(DefinitionLevelTrace, traceIters, newTraceCollector()), nil
 }
 


### PR DESCRIPTION
Move serviceStats iterator to second pass.

Ref. https://github.com/grafana/tempo/pull/3368#discussion_r1491702705

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`